### PR TITLE
Container children are no longer rendered on the page when layout is …

### DIFF
--- a/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
+++ b/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container/responsiveGrid.html
@@ -17,6 +17,6 @@
     <div id="${container.id}"
          class="cmp-container"
          style="${container.backgroundStyle @ context='styleString'}">
-        <sly data-sly-resource="${resource @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
+        <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/responsivegrid'}"></sly>
     </div>
 </template>


### PR DESCRIPTION
…responsiveGrid

* resource could be a wrapped one, so use resource.path for rendering it as foundation responsivegrid

<!--
Before making a PR please make sure to read our contributing guidelines
https://github.com/adobe/aem-core-wcm-components/blob/master/CONTRIBUTING.md

IMPORTANT: Please base your pull request on the **development** branch! The maintainers will cherry-pick the change to
 master after it's successfully integrated and tested.

For issue references: Add a comma-separated list of a [closing word](https://help.github.com/articles/closing-issues-via-commit-messages/)
followed by the ticket number fixed by the PR. It should be underlined in the preview if done correctly.
-->

| Q                        | A <!--(Can use an emoji 👍) -->
| ------------------------ | ---
| Fixed Issues?            | `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
| Patch: Bug Fix?          |
| Minor: New Feature?      |
| Major: Breaking Change?  |
| Tests Added + Pass?      | Yes
| Documentation Provided   | Yes (code comments and or markdown)
| Any Dependency Changes?  |
| License                  | Apache License, Version 2.0

<!-- Describe your changes below in as much detail as possible -->
